### PR TITLE
🔒 [security fix] Remove eval command injection in backup script

### DIFF
--- a/scripts/backup/repo.sh
+++ b/scripts/backup/repo.sh
@@ -16,7 +16,7 @@ if [[ -z "$REPO_PATH" ]]; then
 fi
 
 # Expand the home directory
-REPO_PATH=$(eval echo "$REPO_PATH")
+REPO_PATH=$(python3 -c "import os, sys; print(os.path.expandvars(os.path.expanduser(sys.argv[1])))" "$REPO_PATH")
 
 LOG_DIR="$HOME/.local/share/backup-logs/$REPO_NAME"
 SUCCESS_LOG="$LOG_DIR/success.log"


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a command injection in `scripts/backup/repo.sh` where `eval echo` was used to evaluate the `REPO_PATH` variable extracted from `config.json`.
⚠️ **Risk:** If an attacker modifies `config.json`, they can inject arbitrary shell commands (e.g., `\$HOME; rm -rf /`) which would be executed when the backup script runs.
🛡️ **Solution:** Replaced `eval echo` with a safe Python one-liner `python3 -c "import os, sys; print(os.path.expandvars(os.path.expanduser(sys.argv[1])))"`. This safely expands environment variables like `$HOME` and tildes like `~` without executing the string as shell code.

---
*PR created automatically by Jules for task [16136988132623787894](https://jules.google.com/task/16136988132623787894) started by @lalitmee*