### PR TITLE
🔒 [security fix] remove insecure eval in tmux-sessionizer.sh

### DIFF
--- a/tmux/.config/tmux/scripts/tmux-sessionizer.sh
+++ b/tmux/.config/tmux/scripts/tmux-sessionizer.sh
@@ -7,16 +7,21 @@ search_dirs=(
     ~
 )
 
-# Build the find command dynamically from search_dirs
-find_cmd=""
-for dir in "${search_dirs[@]}"; do
-    depth_flag="-maxdepth 2"  # Default depth
-    [[ "$dir" == "$HOME" ]] && depth_flag="-maxdepth 1"  # Limit home directory depth
-    find_cmd+="find \"$dir\" -mindepth 1 $depth_flag -type d 2>/dev/null; "
-done
-
 # Execute the find commands and pass output to fzf
-selected=$(eval "$find_cmd" | fzf)
+# We use a subshell to aggregate results from multiple find commands securely
+selected=$(
+    for dir in "${search_dirs[@]}"; do
+        # Expand tilde and check if directory exists
+        # In zsh, :A expands to absolute path and resolves symlinks
+        dir_expanded="${dir:A}"
+        [[ ! -d "$dir_expanded" ]] && continue
+
+        depth=2
+        [[ "$dir_expanded" == "$HOME" ]] && depth=1
+
+        find "$dir_expanded" -mindepth 1 -maxdepth "$depth" -type d 2>/dev/null
+    done | fzf
+)
 
 # Exit if nothing is selected
 if [[ -z $selected ]]; then


### PR DESCRIPTION
🎯 **What:** Fixed a security vulnerability in tmux-sessionizer.sh where eval was used to execute a command string built from directory paths.
⚠️ **Risk:** If a directory name contained shell metacharacters, it could lead to arbitrary command execution.
🛡️ **Solution:** Replaced eval with a secure subshell loop that executes find directly for each directory. Used Zsh's `:A` modifier for safe absolute path expansion.

---
*PR created automatically by Jules for task [12375183199553544348](https://jules.google.com/task/12375183199553544348) started by @lalitmee*